### PR TITLE
refactor!: remove streamName parameter from CreateClient API

### DIFF
--- a/Runtime/UniKinesisClient.cs
+++ b/Runtime/UniKinesisClient.cs
@@ -2,7 +2,7 @@ namespace UniKinesisSDK
 {
     public static class UniKinesisClient
     {
-        public static IKinesisClient CreateClient(string kinesisPoolId, string region, string streamName)
+        public static IKinesisClient CreateClient(string kinesisPoolId, string region)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             return new JSKinesisClient(kinesisPoolId, region);


### PR DESCRIPTION
BREAKING CHANGE: The CreateClient interface no longer requires the `streamName` parameter.